### PR TITLE
Update TLP to version 1.6.0

### DIFF
--- a/files/0002-enable_default_settings_in_conf.patch
+++ b/files/0002-enable_default_settings_in_conf.patch
@@ -9,8 +9,8 @@ Subject: [PATCH 2/2] enable_default_settings_in_conf
 
 diff --git a/tlp.conf b/tlp.conf
 index e7f2c8a..92e3e1c 100644
---- a/tlp.conf
-+++ b/tlp.conf
+--- a/tlp.conf.in
++++ b/tlp.conf.in
 @@ -312,8 +312,8 @@
  # Wi-Fi power saving mode: on=enable, off=disable.
  # Default: off (AC), on (BAT)

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : tlp
-version    : 1.5.0
-release    : 17
+version    : 1.6.0
+release    : 18
 source     :
-    - https://github.com/linrunner/TLP/archive/1.5.0.tar.gz : b5f08f00d535c26abc49b336b4c7264c6e5fb7bc3de8054eaabeebdd00e0760e
+    - https://github.com/linrunner/TLP/archive/1.6.0.tar.gz : e34ded54c14d2cc0ad86cfda1e9e05bcc7b9c5c47c14114109423f20c7a2f96c
 license    : GPL-2.0-only
 component  : system.utils
 summary    : Linux Advanced Power Management

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -25,7 +25,6 @@
 </Description>
         <PartOf>system.utils</PartOf>
         <Files>
-            <Path fileType="config">/etc/NetworkManager/dispatcher.d/99tlp-rdw-nm</Path>
             <Path fileType="config">/etc/tlp.conf</Path>
             <Path fileType="config">/etc/tlp.d/00-template.conf</Path>
             <Path fileType="config">/etc/tlp.d/README</Path>
@@ -38,6 +37,7 @@
             <Path fileType="executable">/usr/bin/tlp-stat</Path>
             <Path fileType="executable">/usr/bin/wifi</Path>
             <Path fileType="executable">/usr/bin/wwan</Path>
+            <Path fileType="library">/usr/lib/NetworkManager/dispatcher.d/99tlp-rdw-nm</Path>
             <Path fileType="library">/usr/lib64/systemd/system/multi-user.target.wants/tlp.service</Path>
             <Path fileType="library">/usr/lib64/systemd/system/tlp.service</Path>
             <Path fileType="library">/usr/lib64/udev/rules.d/85-tlp-rdw.rules</Path>
@@ -70,10 +70,14 @@
             <Path fileType="data">/usr/share/tlp/bat.d/25-lenovo</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/30-samsung</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/35-lg</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/36-lg-legacy</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/40-sony</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/45-system76</Path>
+            <Path fileType="data">/usr/share/tlp/bat.d/50-toshiba</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/90-generic</Path>
             <Path fileType="data">/usr/share/tlp/bat.d/TEMPLATE</Path>
             <Path fileType="data">/usr/share/tlp/defaults.conf</Path>
+            <Path fileType="data">/usr/share/tlp/deprecated.conf</Path>
             <Path fileType="data">/usr/share/tlp/func.d/05-tlp-func-pm</Path>
             <Path fileType="data">/usr/share/tlp/func.d/10-tlp-func-cpu</Path>
             <Path fileType="data">/usr/share/tlp/func.d/15-tlp-func-disk</Path>
@@ -90,12 +94,17 @@
             <Path fileType="data">/usr/share/tlp/tlp-readconfs</Path>
             <Path fileType="data">/usr/share/tlp/tlp-usblist</Path>
             <Path fileType="data">/usr/share/tlp/tpacpi-bat</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_tlp</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_tlp-radio-device</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_tlp-rdw</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_tlp-run-on</Path>
+            <Path fileType="data">/usr/share/zsh/site-functions/_tlp-stat</Path>
         </Files>
     </Package>
     <History>
-        <Update release="17">
-            <Date>2022-12-14</Date>
-            <Version>1.5.0</Version>
+        <Update release="18">
+            <Date>2023-08-27</Date>
+            <Version>1.6.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Matthias Homann</Name>
             <Email>palto@mailbox.org</Email>


### PR DESCRIPTION
### Summary

#### Bugfixes

- Operation:  Deactivate AHCI_RUNTIME_PM and PCIE_ASPM before suspend to avoid resume freezes
- Processor: Set governor although not listed in scaling_available_governors

#### Feature Highlights:

- General
  - MEM_SLEEP_ON_AC/BAT: change system suspend mode (deep, s2idle)
  - Add ZSH command completion
  - tlp-stat -s
    - Silence warnings about unmasked systemd-rfkill.service/.socket when DEVICES_TO_ENABLE/DISABLE_ON_STARTUP is actually unconfigured
  - Show system suspend mode
- Battery Care
  - LG Gram laptops:
    - Use standard sysfs attribute charge_control_end_threshold provided by kernel 5.18 and newer
    - Restore threshold after hibernate
  - System76 laptops with open source EC firmware: start and stop threshold
  - ThinkPads: model detection adapted Libreboot
  - Toshiba/Dynabook laptops: stop threshold 80/100%
- Configuration
  - Allow comments (#) after parameters
  - tlp-stat -c/--cdiff: append a notice to deprecated or removed parameters
- PCI(e) devices
  - RUNTIME_PM_ENABLE/DISABLE: apply even when RUNTIME_PM_ON_AC/BAT is disabled
- Processor
  - CPU_DRIVER_OPMODE_ON_AC/BAT: set CPU scaling driver operation mode (active, guided, passive) for amd-pstate or intel_pstate driver
  - CPU_ENERGY_PERF_POLICY_ON_AC/BAT: now supports AMD Zen 2 or newer CPUs (requires amd-pstate driver as of kernel 6.3)
  - SCHED_POWERSAVE_ON_AC/BAT: removed (unavailable since kernel 3.5)
tlp-stat -p:
  - Show amd-pstate operation mode, dynamic boost and performance attributes
  - Show min/max operating frequency the processor can run at (cpuinfo_min/max_freq) and limit imposed by the BIOS (bios_limit)

See the [full changelog](https://github.com/linrunner/TLP/blob/main/changelog) for remaining features and bugfixes.

### Test Plan

- `tlp-stat`can be run
- `tlp` can be started via CLI
- `tlp` service is started at boot

### Checklist

- [x] Package was built and tested against unstable
